### PR TITLE
Add composer.json for composer support (https://getcomposer.org/)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "dominicsayers/isemail",
+    "description": "Checks an email address against the following RFCs: 3696, 1123, 4291, 5321, 5322",
+    "keywords": [
+        "email",
+        "validation"
+    ],
+    "license": "BSD",
+    "homepage": "http://isemail.info",
+    "support": {
+        "source": "https://github.com/dominicsayers/isemail",
+        "issues": "https://github.com/dominicsayers/isemail/issues"
+    },
+    "authors": [
+        {
+            "name": "Dominic Sayers",
+            "email": "dominic@sayers.cc"
+        }
+    ],
+    "autoload": {
+        "files": ["is_email.php"]
+    },
+    "require": {
+
+    }
+}


### PR DESCRIPTION
For a basic composer support, please add this composer.json file to your repository.

Maybe you could register this package on https://packagist.org/.

Right now I added the autoload files feature, maybe I find some time for a PR with added [PSR-4](http://www.php-fig.org/psr/psr-4/) compability.
