### PR TITLE
Add WordPress Compatibilty

### DIFF
--- a/is_email.php
+++ b/is_email.php
@@ -46,6 +46,8 @@
 	require_module 'pcre';
 .*/
 
+namespace dominicsayers;
+
 if (!defined('ISEMAIL_VALID')) {
 /*:diagnostic constants start:*/
 // This part of the code is generated using data from test/meta.xml. Beware of making manual alterations


### PR DESCRIPTION
WordPress sites have the function `is_email` already defined. Wrapping this file in a namespace should extend compatibility to WordPress and other projects. This will also break compatibility with existing projects. I recommend bumping to `4.0.0` according to semantics.