### PR TITLE
Fixing 'Parameter must be an array or an object that implements Count…

### DIFF
--- a/is_email.php
+++ b/is_email.php
@@ -1120,7 +1120,7 @@ if (!defined('ISEMAIL_VALID')) {
 				$return_status[]	= ISEMAIL_DNSWARN_NO_MX_RECORD;		// MX-record for domain can't be found
 				$result			= @dns_get_record($parsedata[ISEMAIL_COMPONENT_DOMAIN], DNS_A + DNS_CNAME);
 
-				if (count($result) === 0)
+				if (($result === false) || (count($result) === 0))
 					$return_status[] = ISEMAIL_DNSWARN_NO_RECORD;		// No usable records for the domain can be found
 			} else $dns_checked = true;
 		}


### PR DESCRIPTION
…able' when handed asdf@asdf

```
$ php -v
PHP 7.2.10-0ubuntu0.18.04.1 (cli) (built: Sep 13 2018 13:45:02) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
    with Zend OPcache v7.2.10-0ubuntu0.18.04.1, Copyright (c) 1999-2018, by Zend Technologies
```
```
$ php -nr 'include("is_email.php"); echo is_email("asdf@asdf", true, true);'

Warning: count(): Parameter must be an array or an object that implements Countable in [...]/is_email.php on line 1123
```

After proposed change:

```
$ php -nr 'include("is_email.php"); echo is_email("asdf@asdf", true, true);'
9
```